### PR TITLE
Allow to override `entrypoint_retry` decorator.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ Release Notes
 
 Semantic versioning is followed.
 
+Version 0.3.0
+-------------
+
+Released 2017-02-02
+
+* Allow to override `random_sigma` and `random_groups_per_sigma` when using
+  `entrypoint_retry` decorator.
+
 Version 0.2.0
 -------------
 

--- a/nameko_amqp_retry/decorators.py
+++ b/nameko_amqp_retry/decorators.py
@@ -4,18 +4,24 @@ import wrapt
 from .backoff import Backoff
 
 
-def backoff_factory(limit=None, schedule=None):
-    retry_limit = Backoff.limit if limit is None else limit
-    retry_schedule = Backoff.schedule if schedule is None else schedule
+def backoff_factory(*args, **kwargs):
+    retry_limit = kwargs.get('limit') or Backoff.limit
+    retry_schedule = kwargs.get('schedule') or Backoff.schedule
+    retry_random_sigma = kwargs.get('random_sigma') or Backoff.random_sigma
+    retry_random_groups_per_sigma = kwargs.get('random_groups_per_sigma') or (
+        Backoff.random_groups_per_sigma
+    )
 
     class CustomBackoff(Backoff):
         schedule = retry_schedule
         limit = retry_limit
+        random_sigma = retry_random_sigma
+        random_groups_per_sigma = retry_random_groups_per_sigma
 
     return CustomBackoff
 
 
-def entrypoint_retry(retry_for=Exception, limit=None, schedule=None):
+def entrypoint_retry(*args, **kwargs):
     """
     Decorator to declare that an entrypoint can be retried on failure.
 
@@ -34,8 +40,17 @@ def entrypoint_retry(retry_for=Exception, limit=None, schedule=None):
     :param schedule: tuple of integers
         A tuple defining the number of milliseconds to wait between each
         retry. If not given, the default `Backoff.schedule` will be used.
+
+    :param random_sigma: integer
+        Standard deviation as milliseconds. If not given,
+        the default `Backoff.random_sigma` will be used.
+
+    :param random_groups_per_sigma: integer
+        Random backoffs are rounded to nearest group. If not given,
+        the default `Backoff.random_groups_per_sigma` will be used.
     """
-    backoff_cls = backoff_factory(limit=limit, schedule=schedule)
+    retry_for = kwargs.get('retry_for') or Exception
+    backoff_cls = backoff_factory(*args, **kwargs)
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-amqp-retry',
-    version='0.2.0',
+    version='0.3.0',
     description='Nameko extension allowing AMQP entrypoints to retry later',
     author='Student.com',
     url='http://github.com/nameko/nameko-amqp-retry',

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -14,7 +14,11 @@ class TestEntrypointRetry(object):
                 raise raises
             return arg1
 
-        @entrypoint_retry(limit=3, schedule=(100, 200))
+        @entrypoint_retry(
+            limit=3,
+            schedule=(100, 200),
+            random_sigma=200,
+            random_groups_per_sigma=10)
         def method2(self, arg1, raises=None, kwarg1=None):
             if raises:
                 raise raises
@@ -49,6 +53,8 @@ class TestEntrypointRetry(object):
 
         assert exc.value.limit == 3
         assert exc.value.schedule == (100, 200)
+        assert exc.value.random_sigma == 200
+        assert exc.value.random_groups_per_sigma == 10
 
     def test_custom_retry_for(self, service):
         # value error will just be raised (it is not in the `retry_for`)


### PR DESCRIPTION
Allow to override `random_sigma` and `random_groups_per_sigma` when using `entrypoint_retry` decorator.