### PR TITLE
Fix for setting custom entrypoint  settings

### DIFF
--- a/nameko_amqp_retry/decorators.py
+++ b/nameko_amqp_retry/decorators.py
@@ -5,12 +5,18 @@ from .backoff import Backoff
 
 
 def backoff_factory(*args, **kwargs):
-    retry_limit = kwargs.get('limit') or Backoff.limit
-    retry_schedule = kwargs.get('schedule') or Backoff.schedule
-    retry_random_sigma = kwargs.get('random_sigma') or Backoff.random_sigma
-    retry_random_groups_per_sigma = kwargs.get('random_groups_per_sigma') or (
-        Backoff.random_groups_per_sigma
-    )
+    limit = kwargs.get('limit')
+    schedule = kwargs.get('schedule')
+    random_sigma = kwargs.get('random_sigma')
+    random_groups_per_sigma = kwargs.get('random_groups_per_sigma')
+
+    retry_limit = Backoff.limit if limit is None else limit
+    retry_schedule = Backoff.schedule if schedule is None else schedule
+    retry_random_sigma = (
+        Backoff.random_sigma if random_sigma is None else random_sigma)
+    retry_random_groups_per_sigma = (
+        Backoff.random_groups_per_sigma if
+        random_groups_per_sigma is None else random_groups_per_sigma)
 
     class CustomBackoff(Backoff):
         schedule = retry_schedule

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -17,7 +17,7 @@ class TestEntrypointRetry(object):
         @entrypoint_retry(
             limit=3,
             schedule=(100, 200),
-            random_sigma=200,
+            random_sigma=0,
             random_groups_per_sigma=10)
         def method2(self, arg1, raises=None, kwarg1=None):
             if raises:
@@ -53,7 +53,7 @@ class TestEntrypointRetry(object):
 
         assert exc.value.limit == 3
         assert exc.value.schedule == (100, 200)
-        assert exc.value.random_sigma == 200
+        assert exc.value.random_sigma == 0
         assert exc.value.random_groups_per_sigma == 10
 
     def test_custom_retry_for(self, service):


### PR DESCRIPTION
Fix for setting custom entrypoint  settings.

I just cut 0.3.0 release when I found this bug. I think we can just retag it. 