### PR TITLE
Ensure exchange and queue declarations are retried

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@ Release Notes
 
 Semantic versioning is followed.
 
+Version 0.3.3
+-------------
+
+Released 2017-04-06
+
+Ensure exchange and queue declaration has retry-policy when re-publishing
+
 Version 0.3.2
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-amqp-retry',
-    version='0.3.2',
+    version='0.3.3',
     description='Nameko extension allowing AMQP entrypoints to retry later',
     author='Student.com',
     url='http://github.com/nameko/nameko-amqp-retry',


### PR DESCRIPTION
When republishing, instead of using `maybe_declare`, we now declare the exchange and queue by passing a `declares` kwarg with the call to kombu `publish`