### PR TITLE
Expose retry info

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ Release Notes
 
 Semantic versioning is followed.
 
+Version 0.3.4
+-------------
+
+Released 2017-06-01
+
+Include next-retry info in the Backoff error description.
+Prevent negative values being used as expiration times.
+
 Version 0.3.3
 -------------
 

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -30,7 +30,8 @@ class Backoff(Exception):
     class Expired(Exception):
         pass
 
-    def __init__(self):
+    def __init__(self, *args):
+        super(Backoff, self).__init__(*args)
         self._total_attempts = None
         self._next_expiration = None
 

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -66,6 +66,9 @@ class Backoff(Exception):
             group_size = self.random_sigma / self.random_groups_per_sigma
             expiration = round_to_nearest(randomised, interval=group_size)
 
+        # Prevent any negative values created by randomness
+        expiration = abs(expiration)
+
         self._result_attempts = total_attempts
         self._result_expiration = expiration
         return expiration

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -65,7 +65,19 @@ class Backoff(Exception):
             randomised = int(random.gauss(expiration, self.random_sigma))
             group_size = self.random_sigma / self.random_groups_per_sigma
             expiration = round_to_nearest(randomised, interval=group_size)
+
+        self._result_attempts = total_attempts
+        self._result_expiration = expiration
         return expiration
+
+    def __str__(self):
+        return '{}({})'.format(
+            type(self),
+            'retry #{} in {}ms'.format(
+                self._result_attempts + 1, self._result_expiration)
+            if hasattr(self, '_result_expiration')
+            else 'next retry not calculated'
+        )
 
 
 class BackoffPublisher(SharedExtension):

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -80,12 +80,11 @@ class Backoff(Exception):
         return expiration
 
     def __str__(self):
-        return '{}({})'.format(
-            type(self),
+        return 'Backoff({})'.format(
             'retry #{} in {}ms'.format(
                 self._total_attempts + 1, self._next_expiration)
             if self._next_expiration is not None
-            else 'not-yet-calculated'
+            else 'uninitialised'
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-amqp-retry',
-    version='0.3.3',
+    version='0.3.4',
     description='Nameko extension allowing AMQP entrypoints to retry later',
     author='Student.com',
     url='http://github.com/nameko/nameko-amqp-retry',

--- a/test/test_backoff.py
+++ b/test/test_backoff.py
@@ -40,8 +40,7 @@ class TestGetNextExpiration(object):
     def test_first_backoff(self, backoff):
         message = Mock()
         message.headers = {}
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 1000
+        assert backoff.next(message, "backoff") == 1000
 
     def test_next_backoff(self, backoff):
         message = Mock()
@@ -52,8 +51,7 @@ class TestGetNextExpiration(object):
                 'count': 1
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 2000
+        assert backoff.next(message, "backoff") == 2000
 
     def test_last_backoff_single_queue(self, backoff):
         message = Mock()
@@ -64,8 +62,7 @@ class TestGetNextExpiration(object):
                 'count': 3
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 3000
+        assert backoff.next(message, "backoff") == 3000
 
     def test_last_backoff_multiple_queues(self, backoff):
         message = Mock()
@@ -80,8 +77,7 @@ class TestGetNextExpiration(object):
                 'count': 1
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 3000
+        assert backoff.next(message, "backoff") == 3000
 
     def test_count_greater_than_schedule_length(self, backoff):
         message = Mock()
@@ -92,8 +88,7 @@ class TestGetNextExpiration(object):
                 'count': 5
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 3000
+        assert backoff.next(message, "backoff") == 3000
 
     def test_count_greater_than_limit(self, backoff):
         message = Mock()
@@ -105,7 +100,7 @@ class TestGetNextExpiration(object):
             }]
         }
         with pytest.raises(Backoff.Expired) as exc_info:
-            backoff.calculate_next_expiration(message, "backoff")
+            backoff.next(message, "backoff")
         # 27 = 1 + 2 + 3 * 8
         assert str(exc_info.value) == (
             "Backoff aborted after '10' retries (~27 seconds)"
@@ -125,7 +120,7 @@ class TestGetNextExpiration(object):
             }]
         }
         with pytest.raises(Backoff.Expired) as exc_info:
-            backoff.calculate_next_expiration(message, "backoff")
+            backoff.next(message, "backoff")
         # 27 = 1 + 2 + 3 * 8
         assert str(exc_info.value) == (
             "Backoff aborted after '10' retries (~27 seconds)"
@@ -140,8 +135,7 @@ class TestGetNextExpiration(object):
                 'count': 99
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 1000
+        assert backoff.next(message, "backoff") == 1000
 
     def test_previously_deadlettered_next_backoff(self, backoff):
         message = Mock()
@@ -161,8 +155,7 @@ class TestGetNextExpiration(object):
                 'count': 99
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 3000
+        assert backoff.next(message, "backoff") == 3000
 
     def test_no_limit(self, backoff_without_limit):
 
@@ -176,8 +169,7 @@ class TestGetNextExpiration(object):
                 'count': 999
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 3000
+        assert backoff.next(message, "backoff") == 3000
 
     @patch('nameko_amqp_retry.backoff.random')
     def test_backoff_randomness(self, random_patch, backoff_with_random_sigma):
@@ -194,8 +186,7 @@ class TestGetNextExpiration(object):
                 'count': 1
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
-        assert backoff.next_expiration == 2200
+        assert backoff.next(message, "backoff") == 2200
         assert random_patch.gauss.call_args_list == [
             call(2000, backoff.random_sigma)
         ]
@@ -220,7 +211,7 @@ class TestGetNextExpiration(object):
                 'count': 1
             }]
         }
-        backoff.calculate_next_expiration(message, "backoff")
+        backoff.next(message, "backoff")
         assert "(retry #4 in 3000ms)" in str(backoff)
 
 

--- a/test/test_backoff.py
+++ b/test/test_backoff.py
@@ -193,10 +193,7 @@ class TestGetNextExpiration(object):
 
     def test_uncalculated_to_string(self):
         backoff = Backoff()
-
-        assert str(backoff) == (
-            "<class 'nameko_amqp_retry.backoff.Backoff'>(not-yet-calculated)"
-        )
+        assert str(backoff) == "Backoff(uninitialised)"
 
     def test_calculated_to_string(self, backoff):
         message = Mock()
@@ -212,7 +209,7 @@ class TestGetNextExpiration(object):
             }]
         }
         backoff.next(message, "backoff")
-        assert "(retry #4 in 3000ms)" in str(backoff)
+        assert "Backoff(retry #4 in 3000ms)" == str(backoff)
 
 
 @pytest.mark.parametrize("value,interval,result", [

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -178,7 +178,7 @@ class TestNegativeExpiration(object):
 
         return container
 
-    def test_negative_expiration(
+    def test_negative_expiration_coerced_to_zero(
         self, container, entrypoint_tracker, rpc_proxy, wait_for_result
     ):
         with entrypoint_waiter(

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -157,6 +157,40 @@ class TestMultipleMessages(object):
         )
 
 
+class TestNegativeExpiration(object):
+
+    @pytest.fixture
+    def container(self, container_factory, rabbit_config, counter):
+
+        class Service(object):
+            name = "service"
+
+            backoff = BackoffPublisher()
+
+            @rpc
+            def bad(self):
+                class BadBackoff(Backoff):
+                    schedule = (-10, )
+                raise BadBackoff()
+
+        container = container_factory(Service, rabbit_config)
+        container.start()
+
+        return container
+
+    def test_negative_expiration(
+        self, container, entrypoint_tracker, rpc_proxy, wait_for_result
+    ):
+        # wait for both entrypoints to generate a result
+        with entrypoint_waiter(
+            container, 'bad', callback=wait_for_result
+        ):
+            # wait for "bad" to fire once before calling "bad",
+            rpc_proxy.service.bad.call_async()
+
+        assert len(entrypoint_tracker.get_results()) > 1;
+
+
 class TestCallStack(object):
 
     @pytest.fixture

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -181,14 +181,12 @@ class TestNegativeExpiration(object):
     def test_negative_expiration(
         self, container, entrypoint_tracker, rpc_proxy, wait_for_result
     ):
-        # wait for both entrypoints to generate a result
         with entrypoint_waiter(
             container, 'bad', callback=wait_for_result
         ):
-            # wait for "bad" to fire once before calling "bad",
             rpc_proxy.service.bad.call_async()
 
-        assert len(entrypoint_tracker.get_results()) > 1;
+        assert len(entrypoint_tracker.get_results()) > 1
 
 
 class TestCallStack(object):


### PR DESCRIPTION
-  Makes sure the Backoff error will display info about the next retry if rendered in a stack-trace.

-  Prevents any negative values being used as expiration times.