### PR TITLE
expire backoff queues after they've delivered their messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TOX_ENV=py34-lib
   - TOX_ENV=py34-examples
 script:
+  - pip -e $TOX_ENV -- pip install eventlet==0.20.0
   - tox -e $TOX_ENV
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   - TOX_ENV=py34-examples
 script:
   - tox -e $TOX_ENV -- pip install eventlet==0.20.0
-  - tox -e $TOX_ENV
 deploy:
   provider: pypi
   user: mattbennett

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - TOX_ENV=py34-lib
   - TOX_ENV=py34-examples
 script:
-  - pip -e $TOX_ENV -- pip install eventlet==0.20.0
+  - tox -e $TOX_ENV -- pip install eventlet==0.20.0
   - tox -e $TOX_ENV
 deploy:
   provider: pypi

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -116,9 +116,7 @@ class BackoffPublisher(SharedExtension):
 
             # force redeclaration; the publisher will skip declaration if
             # the entity has previously been declared by the same connection
-            maybe_declare(
-                queue, conn, retry=True, retry_policy=DEFAULT_RETRY_POLICY
-            )
+            maybe_declare(queue, conn, retry=True, **DEFAULT_RETRY_POLICY)
 
             producer.publish(
                 message.body,

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -8,6 +8,9 @@ from nameko.constants import AMQP_URI_CONFIG_KEY, DEFAULT_RETRY_POLICY
 from nameko.extensions import SharedExtension
 
 
+EXPIRY_GRACE_PERIOD = 100  # ms
+
+
 def get_backoff_queue_name(expiration):
     return "backoff--{}".format(expiration)
 
@@ -87,6 +90,7 @@ class BackoffPublisher(SharedExtension):
                 'x-match': 'any'
             },
             queue_arguments={
+                'x-expires': expiration + EXPIRY_GRACE_PERIOD,
                 'x-dead-letter-exchange': ""   # default exchange
             }
         )

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -116,7 +116,9 @@ class BackoffPublisher(SharedExtension):
 
             # force redeclaration; the publisher will skip declaration if
             # the entity has previously been declared by the same connection
-            maybe_declare(queue, conn)
+            maybe_declare(
+                queue, conn, retry=True, retry_policy=DEFAULT_RETRY_POLICY
+            )
 
             producer.publish(
                 message.body,

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -2,6 +2,7 @@ import random
 
 import six
 from kombu import Connection
+from kombu.common import maybe_declare
 from kombu.messaging import Exchange, Queue
 from kombu.pools import producers
 from nameko.constants import AMQP_URI_CONFIG_KEY, DEFAULT_RETRY_POLICY
@@ -112,6 +113,10 @@ class BackoffPublisher(SharedExtension):
 
             headers['backoff'] = expiration
             expiration_seconds = float(expiration) / 1000
+
+            # force redeclaration; the publisher will skip declaration if
+            # the entity has previously been declared by the same connection
+            maybe_declare(queue, conn)
 
             producer.publish(
                 message.body,

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -8,7 +8,7 @@ from nameko.constants import AMQP_URI_CONFIG_KEY, DEFAULT_RETRY_POLICY
 from nameko.extensions import SharedExtension
 
 
-EXPIRY_GRACE_PERIOD = 100  # ms
+EXPIRY_GRACE_PERIOD = 5000  # ms
 
 
 def get_backoff_queue_name(expiration):

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -129,7 +129,7 @@ class TestQueueExpiry(object):
 
     def test_queues_removed(
         self, container, publish_message, exchange, queue, counter,
-        rabbit_config, rabbit_manager
+        rabbit_config, rabbit_manager, fast_expire
     ):
         """ Backoff queues should be removed after their messages are
         redelivered.
@@ -148,8 +148,7 @@ class TestQueueExpiry(object):
                 publish_message(exchange, delay, routing_key=queue.routing_key)
 
         # wait for long enough for the queues to expire
-        # i.e. max(delays) + EXPIRY_GRACE_PERIOD
-        time.sleep(.2)
+        time.sleep((max(delays) + fast_expire) / 1000.0)
 
         # verify the queues have been removed
         vhost = rabbit_config['vhost']

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,6 +1,6 @@
+import itertools
 import json
 import time
-import itertools
 
 import pytest
 from kombu import Connection
@@ -11,9 +11,11 @@ from mock import ANY, patch
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.extensions import DependencyProvider
 from nameko.testing.services import entrypoint_waiter
+from requests.exceptions import HTTPError
 
 from nameko_amqp_retry import Backoff, BackoffPublisher
-from nameko_amqp_retry.backoff import get_backoff_queue_name
+from nameko_amqp_retry.backoff import (
+    EXPIRY_GRACE_PERIOD, get_backoff_queue_name)
 from nameko_amqp_retry.messaging import consume
 from nameko_amqp_retry.rpc import rpc
 
@@ -92,8 +94,92 @@ class TestPublisher(object):
             assert backoff_queue['messages'] == delays.count(delay)
 
         vhost = rabbit_config['vhost']
-        for delay in delays:
+        for delay in set(delays):
             check_queue(delay)
+
+
+class TestQueueExpiry(object):
+
+    @pytest.yield_fixture(autouse=True)
+    def fast_backoff(self):
+        yield
+
+    @pytest.fixture
+    def container(self, container_factory, rabbit_config, queue):
+
+        class Service(object):
+            name = "service"
+
+            @consume(queue)
+            def backoff(self, delay):
+                class DynamicBackoff(Backoff):
+                    schedule = (delay,)
+                    limit = 1
+                raise DynamicBackoff()
+
+        container = container_factory(Service, rabbit_config)
+        container.start()
+        return container
+
+    def test_queues_removed(
+        self, container, publish_message, exchange, queue, counter,
+        rabbit_config, rabbit_manager
+    ):
+        """ Backoff queues should be removed after their messages are
+        redelivered.
+        """
+        delays = [50, 100, 100, 100, 50]
+
+        def all_expired(worker_ctx, res, exc_info):
+            if not issubclass(exc_info[0], Backoff.Expired):
+                return
+            if counter.increment() == len(delays):
+                return True
+
+        # cause multiple unique backoffs to be raised
+        with entrypoint_waiter(container, 'backoff', callback=all_expired):
+            for delay in delays:
+                publish_message(exchange, delay, routing_key=queue.routing_key)
+
+        # wait for long enough for the queues to expire
+        # i.e. max(delays) + EXPIRY_GRACE_PERIOD
+        time.sleep(.2)
+
+        # verify the queues have been removed
+        vhost = rabbit_config['vhost']
+        for delay in set(delays):
+            with pytest.raises(HTTPError) as raised:
+                rabbit_manager.get_queue(
+                    vhost, get_backoff_queue_name(delay)
+                )
+            assert raised.value.response.status_code == 404
+
+    def test_republishing_redeclares(
+        self, container, publish_message, exchange, queue, counter,
+        rabbit_config, rabbit_manager
+    ):
+        """ Queue expiry must be reset when a new message is published to
+        the backoff queue
+        """
+        delays = [50, 50, 50]
+
+        def all_expired(worker_ctx, res, exc_info):
+            if not issubclass(exc_info[0], Backoff.Expired):
+                return
+            if counter.increment() == len(delays):
+                return True
+
+        # cause multiple unique backoffs to be raised, but wait for
+        # EXPIRY_GRACE_PERIOD between each publish.
+        with entrypoint_waiter(container, 'backoff', callback=all_expired):
+            for delay in delays:
+                publish_message(exchange, delay, routing_key=queue.routing_key)
+                time.sleep(EXPIRY_GRACE_PERIOD / 1000)
+
+        # the entrypoint waiter blocks until every published message expires
+        # (after exactly one backoff). if the subsequent publishes didn't
+        # redeclare the queue, the later messages would be lost when the queue
+        # was removed (50ms + EXPIRY_GRACE_PERIOD after the first publish)
 
 
 class TestMultipleMessages(object):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipsdist = True
 whitelist_externals = make
 
 commands =
+    {posargs}
+
     lib: pip install --editable .[dev]
     lib: make test_lib
 


### PR DESCRIPTION
A small enhancement that tidies up RabbitMQ dashboards by removing empty backoff queues once they've deadlettered their messages.