### PR TITLE
Kombu 4 compatibilty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
         "nameko>=2.7.0",
-        "kombu>=3.0.25,<4"
+        "kombu"
     ],
     extras_require={
         'dev': [

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -157,7 +157,7 @@ class TestEvents(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_services(
         self, dispatch_event, container_factory, entrypoint_tracker,

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -159,7 +159,7 @@ class TestMessaging(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_queues_with_same_exchange_and_routing_key(
         self, container_factory, entrypoint_tracker, rabbit_manager, exchange,
@@ -210,7 +210,11 @@ class TestMessaging(object):
             backoff_queue = rabbit_manager.get_queue(
                 vhost, get_backoff_queue_name(delay)
             )
-            assert backoff_queue['messages'] == 0
+            try:
+                assert backoff_queue['messages'] == 0
+            except KeyError:
+                # When no messages in queue, the key may not be in the dict.
+                pass
 
         service_queue_one = rabbit_manager.get_queue(vhost, queue_one.name)
         service_queue_two = rabbit_manager.get_queue(vhost, queue_two.name)

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -167,7 +167,7 @@ class TestRpc(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_services(
         self, rpc_proxy, wait_for_result, counter, backoff_count,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-lib, py34-examples
+envlist = {py27,py34,py35,py36}-kombu{3,4}-lib, py34-examples
 skipsdist = True
 
 [testenv]
@@ -9,6 +9,8 @@ deps =
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released
     py27: eventlet==0.20.1
+    kombu3: kombu>=3.0.25,<4
+    kombu4: kombu>=4.2.0,<5
 
 commands =
 


### PR DESCRIPTION
- Looks like a typo missed when py3 tests are not double checked (The Expired exception is a member class of nameko_amqp_retry.backoff.Backoff)

- Ensure compatibility with Kombu 4.  The compatibility was broken by celery/kombu@ded6f0c873201ab8a20ac3a1c453f891878e74d8

- Let Nameko decide Kombu version (remove version constraint from setup.py)

- I supposed you wanted to keep backward compatibility, so I added a tox axis for kombu versions
