### PR TITLE
Support Nameko 2.11.0 and v3 prerelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 before_install:
-  - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.5.4-management
+  - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.7.8-management
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,18 @@ matrix:
       env: TOX_ENV=py36-latest-lib
     - stage: lib
       python: 3.7
+      dist: xenial
+      sudo: true
       env: TOX_ENV=py37-oldest-lib
     - stage: lib
       python: 3.7
+      dist: xenial
+      sudo: true
       env: TOX_ENV=py37-latest-lib
     - stage: examples
       python: 3.7
+      dist: xenial
+      sudo: true
       env: TOX_ENV=py37-examples
     - stage: deploy
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,17 @@ matrix:
       python: 2.7
       env: TOX_ENV=py27-latest-lib
     - stage: lib
+      python: 2.7
+      env: TOX_ENV=py27-prerelease-lib
+    - stage: lib
       python: 3.4
       env: TOX_ENV=py34-oldest-lib
     - stage: lib
       python: 3.4
       env: TOX_ENV=py34-latest-lib
+    - stage: lib
+      python: 3.4
+      env: TOX_ENV=py34-prerelease-lib
     - stage: lib
       python: 3.5
       env: TOX_ENV=py35-oldest-lib
@@ -35,11 +41,17 @@ matrix:
       python: 3.5
       env: TOX_ENV=py35-latest-lib
     - stage: lib
+      python: 3.5
+      env: TOX_ENV=py35-prerelease-lib
+    - stage: lib
       python: 3.6
       env: TOX_ENV=py36-oldest-lib
     - stage: lib
       python: 3.6
       env: TOX_ENV=py36-latest-lib
+    - stage: lib
+      python: 3.6
+      env: TOX_ENV=py36-prerelease-lib
     - stage: lib
       python: 3.7
       dist: xenial
@@ -50,6 +62,11 @@ matrix:
       dist: xenial
       sudo: true
       env: TOX_ENV=py37-latest-lib
+    - stage: lib
+      python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOX_ENV=py37-prerelease-lib
     - stage: examples
       python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,37 @@ matrix:
   include:
     - stage: lib
       python: 2.7
-      env: TOX_ENV=py27-lib
+      env: TOX_ENV=py27-oldest-lib
+    - stage: lib
+      python: 2.7
+      env: TOX_ENV=py27-latest-lib
     - stage: lib
       python: 3.4
-      env: TOX_ENV=py34-lib
-    - stage: examples
+      env: TOX_ENV=py34-oldest-lib
+    - stage: lib
       python: 3.4
-      env: TOX_ENV=py34-examples
+      env: TOX_ENV=py34-latest-lib
+    - stage: lib
+      python: 3.5
+      env: TOX_ENV=py35-oldest-lib
+    - stage: lib
+      python: 3.5
+      env: TOX_ENV=py35-latest-lib
+    - stage: lib
+      python: 3.6
+      env: TOX_ENV=py36-oldest-lib
+    - stage: lib
+      python: 3.6
+      env: TOX_ENV=py36-latest-lib
+    - stage: lib
+      python: 3.7
+      env: TOX_ENV=py37-oldest-lib
+    - stage: lib
+      python: 3.7
+      env: TOX_ENV=py37-latest-lib
+    - stage: examples
+      python: 3.7
+      env: TOX_ENV=py37-examples
     - stage: deploy
       script: skip
       deploy:

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -123,7 +123,7 @@ class BackoffPublisher(SharedExtension):
         queue = self.make_queue(expiration)
 
         properties = message.properties.copy()
-        headers = properties.pop('application_headers')
+        headers = properties.pop('application_headers', {})
 
         headers['backoff'] = expiration
         expiration_seconds = float(expiration) / 1000

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -4,11 +4,9 @@ import six
 from kombu import Connection
 from kombu.common import maybe_declare
 from kombu.messaging import Exchange, Queue
-from nameko.amqp.publish import get_producer, UndeliverableMessage
+from nameko.amqp.publish import Publisher
 from nameko.constants import AMQP_URI_CONFIG_KEY, DEFAULT_RETRY_POLICY
 from nameko.extensions import SharedExtension
-from nameko.utils.retry import retry
-from six.moves import queue as PyQueue
 
 EXPIRY_GRACE_PERIOD = 5000  # ms
 
@@ -124,44 +122,33 @@ class BackoffPublisher(SharedExtension):
         expiration = backoff_exc.next(message, self.exchange.name)
         queue = self.make_queue(expiration)
 
-        # republish to appropriate backoff queue
+        properties = message.properties.copy()
+        headers = properties.pop('application_headers')
+
+        headers['backoff'] = expiration
+        expiration_seconds = float(expiration) / 1000
+
         amqp_uri = self.container.config[AMQP_URI_CONFIG_KEY]
-        with get_producer(amqp_uri) as producer:
 
-            properties = message.properties.copy()
-            headers = properties.pop('application_headers')
+        # force redeclaration; the publisher will skip declaration if
+        # the entity has previously been declared by the same connection
+        # (see https://github.com/celery/kombu/pull/884)
+        conn = Connection(amqp_uri)
+        maybe_declare(
+            queue, conn.channel(), retry=True, **DEFAULT_RETRY_POLICY
+        )
 
-            headers['backoff'] = expiration
-            expiration_seconds = float(expiration) / 1000
-
-            # force redeclaration; the publisher will skip declaration if
-            # the entity has previously been declared by the same connection
-            # (see https://github.com/celery/kombu/pull/884)
-            conn = Connection(amqp_uri)
-            maybe_declare(queue, conn, retry=True, **DEFAULT_RETRY_POLICY)
-
-            @retry(for_exceptions=UndeliverableMessage)
-            def publish():
-
-                producer.publish(
-                    message.body,
-                    headers=headers,
-                    exchange=self.exchange,
-                    routing_key=target_queue,
-                    expiration=expiration_seconds,
-                    mandatory=True,
-                    retry=True,
-                    retry_policy=DEFAULT_RETRY_POLICY,
-                    declare=[queue.exchange, queue],
-                    **properties
-                )
-
-                try:
-                    returned_messages = producer.channel.returned_messages
-                    returned = returned_messages.get_nowait()
-                except PyQueue.Empty:
-                    pass
-                else:
-                    raise UndeliverableMessage(returned)
-
-            publish()
+        # republish to appropriate backoff queue
+        publisher = Publisher(amqp_uri)
+        publisher.publish(
+            message.body,
+            headers=headers,
+            exchange=self.exchange,
+            routing_key=target_queue,
+            expiration=expiration_seconds,
+            mandatory=True,
+            retry=True,
+            retry_policy=DEFAULT_RETRY_POLICY,
+            declare=[queue.exchange, queue],
+            **properties
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='http://github.com/nameko/nameko-amqp-retry',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
-        "nameko>=2.11.0",
+        "nameko>=2.7.0",
         "kombu"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     url='http://github.com/nameko/nameko-amqp-retry',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
-        "nameko>=2.7.0",
-        "kombu>=3.0.25,<4"
+        "nameko>=2.11.0",
+        "kombu"
     ],
     extras_require={
         'dev': [

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,7 @@
 import sys
 
+import pkg_resources
+
 PY3 = sys.version_info >= (3, 0)
 PY34 = PY3 and sys.version_info[1] == 4
+NAMEKO3 = pkg_resources.get_distribution("nameko").version.split('.')[0] == '3'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,4 @@
 import sys
 
 PY3 = sys.version_info >= (3, 0)
+PY34 = PY3 and sys.version_info[1] == 4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,10 +5,10 @@ from kombu import Connection
 from kombu.messaging import Exchange, Queue
 from kombu.pools import connections, producers
 from mock import patch
+from nameko.amqp.publish import get_connection
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.standalone.events import event_dispatcher
 from nameko.standalone.rpc import ClusterRpcProxy
-
 from nameko_amqp_retry import Backoff
 from nameko_amqp_retry.events import event_handler
 from nameko_amqp_retry.messaging import consume
@@ -210,3 +210,13 @@ def wait_for_backoff_expired(entrypoint_tracker):
         if exc_info and exc_info[0] is Backoff.Expired:
             return True
     return cb
+
+
+@pytest.fixture
+def queue_info(amqp_uri):
+    def get_queue_info(queue_name):
+        with get_connection(amqp_uri) as conn:
+            queue = Queue(name=queue_name)
+            queue = queue.bind(conn)
+            return queue.queue_declare(passive=True)
+    return get_queue_info

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -6,7 +6,7 @@ from mock import ANY
 from nameko.testing.services import entrypoint_waiter, get_extension
 from nameko_amqp_retry import Backoff
 from nameko_amqp_retry.events import EventHandler, event_handler
-from test import PY3
+from test import PY3, PY34
 
 
 class TestEvents(object):
@@ -155,7 +155,10 @@ class TestEvents(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            if PY34:
+                assert "nameko_amqp_retry.backoff.Expired" in stack
+            else:
+                assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_services(
         self, dispatch_event, container_factory, entrypoint_tracker,

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -4,10 +4,8 @@ import pytest
 import six
 from mock import ANY
 from nameko.testing.services import entrypoint_waiter, get_extension
-
 from nameko_amqp_retry import Backoff
-from nameko_amqp_retry.events import event_handler, EventHandler
-
+from nameko_amqp_retry.events import EventHandler, event_handler
 from test import PY3
 
 

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -7,8 +7,8 @@ from mock import ANY
 from nameko.testing.services import entrypoint_waiter, get_extension
 from nameko_amqp_retry import Backoff
 from nameko_amqp_retry.backoff import get_backoff_queue_name
-from nameko_amqp_retry.messaging import consume, Consumer
-from test import PY3
+from nameko_amqp_retry.messaging import Consumer, consume
+from test import PY3, PY34
 
 
 class TestMessaging(object):
@@ -159,7 +159,10 @@ class TestMessaging(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            if PY34:
+                assert "nameko_amqp_retry.backoff.Expired" in stack
+            else:
+                assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_queues_with_same_exchange_and_routing_key(
         self, container_factory, entrypoint_tracker, rabbit_manager, exchange,

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -167,7 +167,7 @@ class TestMessaging(object):
     def test_multiple_queues_with_same_exchange_and_routing_key(
         self, container_factory, entrypoint_tracker, rabbit_manager, exchange,
         wait_for_result, publish_message, counter, rabbit_config,
-        backoff_count, fast_backoff
+        backoff_count, fast_backoff, queue_info
     ):
         """ Message consumption backoff works when there are muliple queues
         receiving the published message
@@ -208,17 +208,14 @@ class TestMessaging(object):
                 publish_message(exchange, "msg", routing_key="message")
 
         # ensure all messages are processed
-        vhost = rabbit_config['vhost']
         for delay in fast_backoff:
-            backoff_queue = rabbit_manager.get_queue(
-                vhost, get_backoff_queue_name(delay)
-            )
-            assert backoff_queue['messages'] == 0
+            backoff_queue = queue_info(get_backoff_queue_name(delay))
+            assert backoff_queue.message_count == 0
 
-        service_queue_one = rabbit_manager.get_queue(vhost, queue_one.name)
-        service_queue_two = rabbit_manager.get_queue(vhost, queue_two.name)
-        assert service_queue_one['messages'] == 0
-        assert service_queue_two['messages'] == 0
+        service_queue_one = queue_info(queue_one.name)
+        service_queue_two = queue_info(queue_two.name)
+        assert service_queue_one.message_count == 0
+        assert service_queue_two.message_count == 0
 
         assert result_one.get() == "one"
         assert result_two.get() == "two"

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -19,6 +19,8 @@ from nameko_amqp_retry.backoff import get_backoff_queue_name
 from nameko_amqp_retry.messaging import consume
 from nameko_amqp_retry.rpc import rpc
 
+from test import NAMEKO3
+
 
 class QuickBackoff(Backoff):
     schedule = (100,)
@@ -324,7 +326,7 @@ class TestCallStack(object):
         with entrypoint_waiter(container, 'method', callback=callback):
             rpc_proxy.service.method("msg")
 
-        assert call_stacks == [
+        expected = [
             [
                 'standalone_rpc_proxy.call.0',
                 'service.method.1'
@@ -348,6 +350,12 @@ class TestCallStack(object):
                 'service.method.4'
             ],
         ]
+
+        if NAMEKO3:  # pragma: no cover
+            for stack in expected:
+                stack[0] = stack[0].replace("proxy", "client").replace("call", "0")
+
+        assert call_stacks == expected
 
     @pytest.mark.usefixtures('predictable_call_ids')
     def test_events_call_stack(self, container, dispatch_event):

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -5,11 +5,9 @@ import six
 from mock import ANY, patch
 from nameko.exceptions import RemoteError
 from nameko.testing.services import entrypoint_waiter, get_extension
-
 from nameko_amqp_retry import Backoff
 from nameko_amqp_retry.rpc import Rpc, rpc
-
-from test import PY3
+from test import PY3, PY34
 
 
 class TestRpc(object):
@@ -167,7 +165,10 @@ class TestRpc(object):
             stack = "".join(traceback.format_exception(exc_type, exc, tb))
             assert "NotYet: try again later" in stack
             assert "nameko_amqp_retry.backoff.Backoff" in stack
-            assert "nameko_amqp_retry.backoff.Expired" in stack
+            if PY34:
+                assert "nameko_amqp_retry.backoff.Expired" in stack
+            else:
+                assert "nameko_amqp_retry.backoff.Backoff.Expired" in stack
 
     def test_multiple_services(
         self, rpc_proxy, wait_for_result, counter, backoff_count,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}-{oldest,latest}-lib, py37-examples
+envlist = {py27,py34,py35,py36,py37}-{oldest,latest,prerelease}-lib, py37-examples
 skipsdist = True
 
 [testenv]
@@ -16,6 +16,8 @@ commands =
 
     lib: pip install --editable .[dev]
     lib: make test_lib
+
+    prerelease: pip install --pre --upgrade nameko
 
     examples: pip install --editable .[dev,examples]
     examples: make test_examples

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-lib, py34-examples
+envlist = {py27,py34,py35,py36}-{oldest,latest}-lib, py34-examples
 skipsdist = True
 
 [testenv]
@@ -9,6 +9,8 @@ deps =
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released
     py27: eventlet==0.20.1
+
+    oldest: nameko==2.7.0
 
 commands =
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-{oldest,latest}-lib, py34-examples
+envlist = {py27,py34,py35,py36,py37}-{oldest,latest}-lib, py37-examples
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Changes:
* Use the `Publisher` from `nameko.amqp.publish` in the backoff publisher
* Remove the retry mechanism in the publisher, because Kombu 4 doesn't raise multiple times
* Test on Python > 3.4

Delgating to the  `Publisher` utility means we can run against multiple versions of Nameko and whatever versions of Kombu that it chooses.

Additional changes for compatibility with the 3.x prerelease (3a10df6):
* `ack_message` has moved from `queue_consumer` to `consumer`, so a try/except is added
* the call stack format has changed slightly, so a conditional is added