### PR TITLE
kombu 4.3 doesn't need maybe_declare

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,13 @@ Release Notes
 Semantic versioning is followed.
 
 
+Version 0.7.1
+-------------
+Released 2019-03-25
+
+* Compatibility fix for kombu > 4.3.0 
+
+
 Version 0.7.0
 -------------
 

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -12,6 +12,9 @@ from nameko.extensions import SharedExtension
 EXPIRY_GRACE_PERIOD = 5000  # ms
 
 
+KOMBU_PRE_4_3 = parse_version(kombu_version) < parse_version('4.3.0')
+
+
 def get_backoff_queue_name(expiration):
     return "backoff--{}ms".format(expiration)
 
@@ -133,10 +136,10 @@ class BackoffPublisher(SharedExtension):
 
         # force redeclaration;
         # In kombu versions prior to 4.3.0, the publisher will skip declaration if
-        # the entity has previously been declared by the same connection
+        # the entity has previously been declared by the same connection.
         # (see https://github.com/celery/kombu/pull/884)
         conn = Connection(amqp_uri)
-        if parse_version(kombu_version) < parse_version('4.3.0'):
+        if KOMBU_PRE_4_3:  # pragma: no cover
             maybe_declare(
                 queue, conn.channel(), retry=True, **DEFAULT_RETRY_POLICY
             )

--- a/nameko_amqp_retry/backoff.py
+++ b/nameko_amqp_retry/backoff.py
@@ -132,7 +132,7 @@ class BackoffPublisher(SharedExtension):
         amqp_uri = self.container.config[AMQP_URI_CONFIG_KEY]
 
         # force redeclaration;
-        # In kombu versions prior to 4.3.0 the publisher will skip declaration if
+        # In kombu versions prior to 4.3.0, the publisher will skip declaration if
         # the entity has previously been declared by the same connection
         # (see https://github.com/celery/kombu/pull/884)
         conn = Connection(amqp_uri)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-amqp-retry',
-    version='0.7.0',
+    version='0.7.1',
     description='Nameko extension allowing AMQP entrypoints to retry later',
     author='Student.com',
     url='http://github.com/nameko/nameko-amqp-retry',


### PR DESCRIPTION
kombu >= 4.3.0 raises a `NotBoundError` on the maybe_declare call.
kombu versions prior to this needed  this extra call for the retries to function reliably.